### PR TITLE
Doubleclicking slide listing doesn't set slide title

### DIFF
--- a/engine/projection.js
+++ b/engine/projection.js
@@ -152,18 +152,30 @@
 		return page + " - " + fragment;
 	}
 
-	function displayCurrentSlide() {
-		var slide, fragment, element, url;
-
-		slide = slideList[currentPosition];
-	
-		fragment = fileToFragment(slide);
-
+	function setTitle(fragment) {
+		if (typeof fragment == "undefined") {
+			fragment = getFragment()
+		}
 		if (mode == "list") {
 			document.title = "All Slides";
 		} else {
 			document.title = fragmentToTitle(fragment);
 		}
+	}
+
+	function getFragment() {
+		var slide, fragment; 
+		slide = slideList[currentPosition];
+
+		fragment = fileToFragment(slide);
+		return fragment
+	}
+
+	function displayCurrentSlide() {
+		var slide, fragment, element, url;
+
+		fragment = getFragment()
+		setTitle(fragment)
 
 		url = window.location.origin + window.location.pathname + window.location.search + "#" + fragment;
   		history.replaceState(null, null, url);
@@ -186,6 +198,7 @@
 		$("body").addClass("full");
 
 		mode = "full";
+		setTitle()
 		doScaleBody();
 
 		url = window.location.origin + window.location.pathname + window.location.hash;


### PR DESCRIPTION
The codepath to set the document title was only followed if
`displayCurrentSlide` was invoked, which was specifically disabled in
the dblclick event listener. If the slide is selected from the list with
an enter, per the keydown event listener, this codepath is followed.

Solution: abstract out the document.title changing into it's own method,
and call this from both displayCurrentSlide and switchToFull
